### PR TITLE
feat: add goforgo update command and change all exercises to run mode

### DIFF
--- a/exercises/01_basics/formatting.toml
+++ b/exercises/01_basics/formatting.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "10s"
 
 [hints]

--- a/exercises/03_functions/closures.toml
+++ b/exercises/03_functions/closures.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["closures.go"]
 

--- a/exercises/03_functions/embedded_methods.toml
+++ b/exercises/03_functions/embedded_methods.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["embedded_methods.go"]
 

--- a/exercises/03_functions/function_definition.toml
+++ b/exercises/03_functions/function_definition.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["function_definition.go"]
 

--- a/exercises/03_functions/function_types.toml
+++ b/exercises/03_functions/function_types.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["function_types.go"]
 

--- a/exercises/03_functions/method_sets.toml
+++ b/exercises/03_functions/method_sets.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["method_sets.go"]
 

--- a/exercises/03_functions/methods_basics.toml
+++ b/exercises/03_functions/methods_basics.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["methods_basics.go"]
 

--- a/exercises/03_functions/named_returns.toml
+++ b/exercises/03_functions/named_returns.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["named_returns.go"]
 

--- a/exercises/03_functions/parameters.toml
+++ b/exercises/03_functions/parameters.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["parameters.go"]
 

--- a/exercises/03_functions/pointer_receivers.toml
+++ b/exercises/03_functions/pointer_receivers.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["pointer_receivers.go"]
 

--- a/exercises/03_functions/recursive_functions.toml
+++ b/exercises/03_functions/recursive_functions.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["recursive_functions.go"]
 

--- a/exercises/03_functions/return_values.toml
+++ b/exercises/03_functions/return_values.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["return_values.go"]
 

--- a/exercises/03_functions/variadic_functions.toml
+++ b/exercises/03_functions/variadic_functions.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["variadic_functions.go"]
 

--- a/exercises/04_control_flow/break_continue.toml
+++ b/exercises/04_control_flow/break_continue.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["break_continue.go"]
 

--- a/exercises/04_control_flow/defer_statements.toml
+++ b/exercises/04_control_flow/defer_statements.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["defer_statements.go"]
 

--- a/exercises/04_control_flow/for_loops.toml
+++ b/exercises/04_control_flow/for_loops.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["for_loops.go"]
 

--- a/exercises/04_control_flow/goto_labels.toml
+++ b/exercises/04_control_flow/goto_labels.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["goto_labels.go"]
 

--- a/exercises/04_control_flow/if_statements.toml
+++ b/exercises/04_control_flow/if_statements.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["if_statements.go"]
 

--- a/exercises/04_control_flow/panic_recover.toml
+++ b/exercises/04_control_flow/panic_recover.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["panic_recover.go"]
 

--- a/exercises/04_control_flow/range_loops.toml
+++ b/exercises/04_control_flow/range_loops.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["range_loops.go"]
 

--- a/exercises/04_control_flow/select_statements.toml
+++ b/exercises/04_control_flow/select_statements.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["select_statements.go"]
 

--- a/exercises/04_control_flow/switch_statements.toml
+++ b/exercises/04_control_flow/switch_statements.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["switch_statements.go"]
 

--- a/exercises/04_control_flow/type_switches.toml
+++ b/exercises/04_control_flow/type_switches.toml
@@ -15,7 +15,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 required_files = ["type_switches.go"]
 

--- a/exercises/05_arrays/array_basics.toml
+++ b/exercises/05_arrays/array_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/05_arrays/array_iteration.toml
+++ b/exercises/05_arrays/array_iteration.toml
@@ -16,7 +16,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/05_arrays/multidimensional_arrays.toml
+++ b/exercises/05_arrays/multidimensional_arrays.toml
@@ -16,7 +16,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/06_slices/slice_append.toml
+++ b/exercises/06_slices/slice_append.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/06_slices/slice_basics.toml
+++ b/exercises/06_slices/slice_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/06_slices/slice_copy.toml
+++ b/exercises/06_slices/slice_copy.toml
@@ -16,7 +16,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/06_slices/slice_tricks.toml
+++ b/exercises/06_slices/slice_tricks.toml
@@ -18,7 +18,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/07_maps/map_advanced.toml
+++ b/exercises/07_maps/map_advanced.toml
@@ -18,7 +18,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/07_maps/map_basics.toml
+++ b/exercises/07_maps/map_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/07_maps/map_iteration.toml
+++ b/exercises/07_maps/map_iteration.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/08_structs/struct_basics.toml
+++ b/exercises/08_structs/struct_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/08_structs/struct_embedding.toml
+++ b/exercises/08_structs/struct_embedding.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/08_structs/struct_methods.toml
+++ b/exercises/08_structs/struct_methods.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/08_structs/struct_tags.toml
+++ b/exercises/08_structs/struct_tags.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/09_interfaces/interface_assertion.toml
+++ b/exercises/09_interfaces/interface_assertion.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/09_interfaces/interface_basics.toml
+++ b/exercises/09_interfaces/interface_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/09_interfaces/interface_composition.toml
+++ b/exercises/09_interfaces/interface_composition.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/09_interfaces/interface_empty.toml
+++ b/exercises/09_interfaces/interface_empty.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/10_errors/error_basics.toml
+++ b/exercises/10_errors/error_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/10_errors/error_custom.toml
+++ b/exercises/10_errors/error_custom.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/10_errors/error_wrapping.toml
+++ b/exercises/10_errors/error_wrapping.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/11_concurrency/channels_basics.toml
+++ b/exercises/11_concurrency/channels_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/11_concurrency/context_usage.toml
+++ b/exercises/11_concurrency/context_usage.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/11_concurrency/goroutines_basics.toml
+++ b/exercises/11_concurrency/goroutines_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/11_concurrency/sync_primitives.toml
+++ b/exercises/11_concurrency/sync_primitives.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/12_generics/generic_basics.toml
+++ b/exercises/12_generics/generic_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/12_generics/generic_constraints.toml
+++ b/exercises/12_generics/generic_constraints.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/12_generics/generic_data_structures.toml
+++ b/exercises/12_generics/generic_data_structures.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/13_testing/test_doubles.toml
+++ b/exercises/13_testing/test_doubles.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/14_stdlib/regexp_advanced.toml
+++ b/exercises/14_stdlib/regexp_advanced.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/14_stdlib/strings_manipulation.toml
+++ b/exercises/14_stdlib/strings_manipulation.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/14_stdlib/time_operations.toml
+++ b/exercises/14_stdlib/time_operations.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/15_json/json_basics.toml
+++ b/exercises/15_json/json_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/15_json/json_streaming.toml
+++ b/exercises/15_json/json_streaming.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/15_json/json_validation.toml
+++ b/exercises/15_json/json_validation.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/16_http/http_client.toml
+++ b/exercises/16_http/http_client.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/16_http/http_middleware.toml
+++ b/exercises/16_http/http_middleware.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/17_files/file_operations.toml
+++ b/exercises/17_files/file_operations.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/17_files/file_permissions.toml
+++ b/exercises/17_files/file_permissions.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/17_files/file_watching.toml
+++ b/exercises/17_files/file_watching.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/18_regex/regex_advanced.toml
+++ b/exercises/18_regex/regex_advanced.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/18_regex/regex_basics.toml
+++ b/exercises/18_regex/regex_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/18_regex/regex_parsing.toml
+++ b/exercises/18_regex/regex_parsing.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/19_reflection/reflection_advanced.toml
+++ b/exercises/19_reflection/reflection_advanced.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/19_reflection/reflection_basics.toml
+++ b/exercises/19_reflection/reflection_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/19_reflection/reflection_practical.toml
+++ b/exercises/19_reflection/reflection_practical.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/20_advanced/context_patterns.toml
+++ b/exercises/20_advanced/context_patterns.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/20_advanced/design_patterns.toml
+++ b/exercises/20_advanced/design_patterns.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/20_advanced/pipeline_patterns.toml
+++ b/exercises/20_advanced/pipeline_patterns.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/21_crypto/digital_signatures.toml
+++ b/exercises/21_crypto/digital_signatures.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/21_crypto/encryption_aes.toml
+++ b/exercises/21_crypto/encryption_aes.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/21_crypto/hashing_basics.toml
+++ b/exercises/21_crypto/hashing_basics.toml
@@ -16,7 +16,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/22_net/http_client_advanced.toml
+++ b/exercises/22_net/http_client_advanced.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/22_net/tcp_client.toml
+++ b/exercises/22_net/tcp_client.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/22_net/tcp_client_server.toml
+++ b/exercises/22_net/tcp_client_server.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/22_net/tcp_server.toml
+++ b/exercises/22_net/tcp_server.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/22_net/udp_communication.toml
+++ b/exercises/22_net/udp_communication.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/23_encoding/base64_encoding.toml
+++ b/exercises/23_encoding/base64_encoding.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/23_encoding/json_advanced.toml
+++ b/exercises/23_encoding/json_advanced.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/23_encoding/json_basics.toml
+++ b/exercises/23_encoding/json_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/24_io/buffered_io.toml
+++ b/exercises/24_io/buffered_io.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/24_io/io_interfaces.toml
+++ b/exercises/24_io/io_interfaces.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/24_io/io_streaming.toml
+++ b/exercises/24_io/io_streaming.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/25_paths/directory_operations.toml
+++ b/exercises/25_paths/directory_operations.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/25_paths/filepath_operations.toml
+++ b/exercises/25_paths/filepath_operations.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/25_paths/path_manipulation.toml
+++ b/exercises/25_paths/path_manipulation.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/26_os/environment_variables.toml
+++ b/exercises/26_os/environment_variables.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/26_os/process_management.toml
+++ b/exercises/26_os/process_management.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/26_os/signal_handling.toml
+++ b/exercises/26_os/signal_handling.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/27_math/geometry.toml
+++ b/exercises/27_math/geometry.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/27_math/number_theory.toml
+++ b/exercises/27_math/number_theory.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/27_math/statistics.toml
+++ b/exercises/27_math/statistics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/28_sorting/search_algorithms.toml
+++ b/exercises/28_sorting/search_algorithms.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/28_sorting/sorting_algorithms.toml
+++ b/exercises/28_sorting/sorting_algorithms.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/28_sorting/sorting_comparison.toml
+++ b/exercises/28_sorting/sorting_comparison.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/29_data_structures/linked_list.toml
+++ b/exercises/29_data_structures/linked_list.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/29_data_structures/stack_queue.toml
+++ b/exercises/29_data_structures/stack_queue.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/29_data_structures/tree_traversal.toml
+++ b/exercises/29_data_structures/tree_traversal.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/30_algorithms/dynamic_programming.toml
+++ b/exercises/30_algorithms/dynamic_programming.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/30_algorithms/graph_algorithms.toml
+++ b/exercises/30_algorithms/graph_algorithms.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/30_algorithms/pattern_matching.toml
+++ b/exercises/30_algorithms/pattern_matching.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/31_web/http_middleware.toml
+++ b/exercises/31_web/http_middleware.toml
@@ -16,7 +16,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/31_web/http_server_basic.toml
+++ b/exercises/31_web/http_server_basic.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/31_web/websocket_chat.toml
+++ b/exercises/31_web/websocket_chat.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/32_microservices/distributed_tracing.toml
+++ b/exercises/32_microservices/distributed_tracing.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/32_microservices/service_discovery.toml
+++ b/exercises/32_microservices/service_discovery.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/33_databases/connection_pool.toml
+++ b/exercises/33_databases/connection_pool.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/33_databases/nosql_embedded.toml
+++ b/exercises/33_databases/nosql_embedded.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/34_grpc/grpc_basics.toml
+++ b/exercises/34_grpc/grpc_basics.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/34_grpc/grpc_interceptors.toml
+++ b/exercises/34_grpc/grpc_interceptors.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/exercises/34_grpc/grpc_streaming.toml
+++ b/exercises/34_grpc/grpc_streaming.toml
@@ -17,7 +17,7 @@ learning_objectives = [
 ]
 
 [validation]
-mode = "build"
+mode = "run"
 timeout = "30s"
 
 [hints]

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stonecharioteer/goforgo/internal/exercise"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update exercise source files without overwriting completed work",
+	Long: `Update exercise source files (like .toml configuration files) from the binary
+without overwriting Go files for exercises you've already completed. This allows you
+to get updates to exercise metadata while preserving your solutions.
+
+This command will:
+- Update all .toml configuration files
+- Update .go files only for incomplete exercises
+- Preserve your completed exercise solutions
+- Keep your progress intact`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := GetWorkingDirectory()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+
+		// Check if this looks like a goforgo directory
+		if _, err := os.Stat(filepath.Join(cwd, ".goforgo.toml")); err != nil {
+			return fmt.Errorf("this doesn't appear to be a GoForGo directory (no .goforgo.toml found)")
+		}
+
+		fmt.Println("🔄 Updating GoForGo exercise files...")
+
+		// Load exercise manager to get completion status
+		em := exercise.NewExerciseManager(cwd)
+		if err := em.LoadExercises(); err != nil {
+			return fmt.Errorf("failed to load exercises: %w", err)
+		}
+
+		// Get completed exercises
+		completedExercises := em.GetCompletedExercises()
+		fmt.Printf("📊 Found %d completed exercises to preserve\n", len(completedExercises))
+
+		// Update exercise files selectively
+		if err := updateExerciseFiles(cwd, completedExercises); err != nil {
+			return fmt.Errorf("failed to update exercise files: %w", err)
+		}
+
+		fmt.Println("✅ GoForGo exercises updated successfully!")
+		fmt.Println("💡 Your completed exercise solutions have been preserved.")
+		return nil
+	},
+}
+
+func updateExerciseFiles(baseDir string, completedExercises map[string]bool) error {
+	sourceExercises := ""
+	sourceSolutions := ""
+
+	// Find source directories (same logic as initialize.go)
+	execPath, err := os.Executable()
+	if err != nil {
+		execPath = ""
+	}
+
+	var possiblePaths []string
+	if execPath != "" {
+		execDir := filepath.Dir(execPath)
+		possiblePaths = append(possiblePaths,
+			filepath.Join(execDir, "exercises"),
+			filepath.Join(execDir, "..", "exercises"),
+			filepath.Join(execDir, "..", "..", "exercises"),
+		)
+	}
+
+	possiblePaths = append(possiblePaths,
+		"exercises",
+		"../exercises",
+		"../../exercises",
+	)
+
+	for _, path := range possiblePaths {
+		if _, err := os.Stat(path); err == nil {
+			sourceExercises = path
+			sourceSolutions = strings.Replace(path, "exercises", "solutions", 1)
+			break
+		}
+	}
+
+	if sourceExercises == "" {
+		return fmt.Errorf("no source exercises found in binary location")
+	}
+
+	fmt.Printf("📂 Updating from source: %s\n", sourceExercises)
+
+	// Walk through source exercises and update selectively
+	err = filepath.Walk(sourceExercises, func(srcPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(sourceExercises, srcPath)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(baseDir, "exercises", relPath)
+
+		if info.IsDir() {
+			// Ensure directory exists
+			return os.MkdirAll(destPath, 0755)
+		}
+
+		// Determine if we should update this file
+		shouldUpdate := shouldUpdateFile(srcPath, destPath, relPath, completedExercises)
+		
+		if shouldUpdate {
+			fmt.Printf("  📝 Updating: %s\n", relPath)
+			return copyFile(srcPath, destPath)
+		} else {
+			fmt.Printf("  ⏭️  Preserving: %s (exercise completed)\n", relPath)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update exercises: %w", err)
+	}
+
+	// Update solutions directory too (these are reference solutions)
+	if _, err := os.Stat(sourceSolutions); err == nil {
+		fmt.Printf("📂 Updating solutions from: %s\n", sourceSolutions)
+		return filepath.Walk(sourceSolutions, func(srcPath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			relPath, err := filepath.Rel(sourceSolutions, srcPath)
+			if err != nil {
+				return err
+			}
+			destPath := filepath.Join(baseDir, "solutions", relPath)
+
+			if info.IsDir() {
+				return os.MkdirAll(destPath, 0755)
+			}
+
+			fmt.Printf("  📝 Updating solution: %s\n", relPath)
+			return copyFile(srcPath, destPath)
+		})
+	}
+
+	return nil
+}
+
+func shouldUpdateFile(srcPath, destPath, relPath string, completedExercises map[string]bool) bool {
+	// Always update .toml files (configuration/metadata)
+	if strings.HasSuffix(relPath, ".toml") {
+		return true
+	}
+
+	// Always update non-.go files (README, scripts, etc.)
+	if !strings.HasSuffix(relPath, ".go") {
+		return true
+	}
+
+	// For .go files, extract exercise name from path and check completion
+	exerciseName := extractExerciseName(relPath)
+	if exerciseName == "" {
+		// Can't determine exercise name, update it to be safe
+		return true
+	}
+
+	// If the exercise is completed, don't update the .go file (preserve user's work)
+	if completedExercises[exerciseName] {
+		return false
+	}
+
+	// Exercise is not completed, safe to update
+	return true
+}
+
+func extractExerciseName(relPath string) string {
+	// Extract exercise name from path like "04_control_flow/range_loops.go"
+	// Returns "range_loops"
+	if strings.HasSuffix(relPath, ".go") {
+		base := filepath.Base(relPath)
+		return strings.TrimSuffix(base, ".go")
+	}
+	return ""
+}
+
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+}

--- a/internal/exercise/exercise.go
+++ b/internal/exercise/exercise.go
@@ -335,6 +335,11 @@ func (em *ExerciseManager) GetCompletedExerciseCount() int {
 	return count
 }
 
+// GetCompletedExercises returns a map of completed exercise names
+func (em *ExerciseManager) GetCompletedExercises() map[string]bool {
+	return em.progress.CompletedExercises
+}
+
 // GetProgressStats returns completed count, total count, and percentage
 func (em *ExerciseManager) GetProgressStats() (completed int, total int, percentage float64) {
 	completed = em.GetCompletedExerciseCount()


### PR DESCRIPTION
- Add new `goforgo update` command that selectively updates exercise files
- Preserves completed exercise .go files while updating all .toml metadata
- Change all exercises from mode="build" to mode="run" for visible output
- Add GetCompletedExercises method to ExerciseManager
- Update command respects user progress and prevents work loss

This allows users to get updates to exercise configuration while keeping
their completed solutions intact. Now all exercises show program output
in the TUI output pane instead of just compilation status.
