### PR TITLE
Fix watch-mode memory creep and harden watcher/runner memory behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to GoForGo will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Memory creep in watch mode** *(2026-04-07 11:15:00 local)*: eliminated duplicate in-flight file watcher wait commands in TUI to prevent goroutine buildup during long sessions.
+- **Watcher shutdown race** *(2026-04-07 11:15:00 local)*: reworked watcher lifecycle with coordinated shutdown (`done` channel + `WaitGroup` + `sync.Once`) to avoid send-on-closed-channel/data-race behavior.
+- **Exercise reload growth** *(2026-04-07 11:15:00 local)*: `ExerciseManager.LoadExercises()` now clears the in-memory slice before rescanning to prevent duplicate accumulation.
+- **Runner output memory pressure** *(2026-04-07 11:15:00 local)*: capped stdout/stderr capture buffers with truncation notices to prevent unbounded output allocations.
+- **Validation concurrency safety** *(2026-04-07 11:15:00 local)*: protected shared validation maps in orchestrator parallel paths to avoid concurrent write races.
+
 ## [0.9.0] - 2026-03-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-07
+
 ### Fixed
 - **Memory creep in watch mode** *(2026-04-07 11:15:00 local)*: eliminated duplicate in-flight file watcher wait commands in TUI to prevent goroutine buildup during long sessions.
 - **Watcher shutdown race** *(2026-04-07 11:15:00 local)*: reworked watcher lifecycle with coordinated shutdown (`done` channel + `WaitGroup` + `sync.Once`) to avoid send-on-closed-channel/data-race behavior.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version = "dev"
+	version = "0.9.1"
 	commit  = "unknown"
 	date    = "unknown"
 	

--- a/internal/exercise/exercise.go
+++ b/internal/exercise/exercise.go
@@ -105,6 +105,9 @@ func (em *ExerciseManager) LoadExercises() error {
 		return fmt.Errorf("exercises directory not found at %s. Run 'goforgo init' first", em.ExercisesPath)
 	}
 
+	// Reset in-memory list before reloading to avoid duplicate growth on repeated calls.
+	em.exercises = em.exercises[:0]
+
 	// Walk through the exercises directory
 	err := filepath.Walk(em.ExercisesPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -44,6 +44,50 @@ type Runner struct {
 	timeout    time.Duration
 }
 
+const maxCommandOutputBytes = 512 * 1024 // 512KB per stream
+
+type cappedOutputBuffer struct {
+	buf     bytes.Buffer
+	max     int
+	dropped int
+}
+
+func newCappedOutputBuffer(max int) *cappedOutputBuffer {
+	return &cappedOutputBuffer{max: max}
+}
+
+func (b *cappedOutputBuffer) Write(p []byte) (int, error) {
+	if b.max <= 0 {
+		b.dropped += len(p)
+		return len(p), nil
+	}
+
+	remaining := b.max - b.buf.Len()
+	if remaining > 0 {
+		toWrite := len(p)
+		if toWrite > remaining {
+			toWrite = remaining
+		}
+		if toWrite > 0 {
+			_, _ = b.buf.Write(p[:toWrite])
+		}
+		if toWrite < len(p) {
+			b.dropped += len(p) - toWrite
+		}
+		return len(p), nil
+	}
+
+	b.dropped += len(p)
+	return len(p), nil
+}
+
+func (b *cappedOutputBuffer) String() string {
+	if b.dropped == 0 {
+		return b.buf.String()
+	}
+	return fmt.Sprintf("%s\n...[output truncated, %d bytes omitted]", b.buf.String(), b.dropped)
+}
+
 // NewRunner creates a new runner with the specified working directory
 func NewRunner(workingDir string) *Runner {
 	return &Runner{
@@ -214,10 +258,11 @@ func (r *Runner) runGoCommand(dir, command string, args ...string) (success bool
 	cmd := exec.CommandContext(ctx, "go", cmdArgs...)
 	cmd.Dir = dir
 
-	// Capture both stdout and stderr
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Capture both stdout and stderr with bounded buffers to avoid memory blowups.
+	stdout := newCappedOutputBuffer(maxCommandOutputBytes)
+	stderr := newCappedOutputBuffer(maxCommandOutputBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	// Run the command
 	err = cmd.Run()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -39,8 +39,9 @@ type Model struct {
 	currentHintLevel int  // Track current hint level (0=none, 1=level1, 2=level1+2, 3=all)
 
 	// File watching
-	watcher    *watcher.Watcher
-	watcherErr error
+	watcher          *watcher.Watcher
+	watcherErr       error
+	watcherListening bool
 
 	// UI state
 	viewMode ViewMode
@@ -144,10 +145,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Auto-advance: show success screen then move to next exercise
 		if msg.result.Success && m.autoAdvance && m.currentIndex < len(m.exercises)-1 {
 			m.showingSuccess = true
-			return m, tea.Batch(m.waitForFileChange(m.watcher), m.autoAdvanceTick())
+			return m, tea.Batch(m.autoAdvanceTick(), m.armFileWatcher())
 		}
 
-		return m, m.waitForFileChange(m.watcher)
+		return m, m.armFileWatcher()
 
 	case exerciseRunningMsg:
 		m.isRunning = true
@@ -155,21 +156,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fileChangedMsg:
+		m.watcherListening = false
 		if !m.isRunning {
-			return m, m.runCurrentExercise()
+			return m, tea.Batch(m.runCurrentExercise(), m.armFileWatcher())
 		}
-		return m, nil
+		return m, m.armFileWatcher()
 
 	case watcherErrorMsg:
+		m.watcherListening = false
 		m.watcherErr = msg.err
 		return m, nil
 
 	case continueWatchingMsg:
+		m.watcherListening = false
 		// Continue listening for file changes
-		if m.watcher != nil {
-			return m, m.waitForFileChange(m.watcher)
-		}
-		return m, nil
+		return m, m.armFileWatcher()
 
 	case autoAdvanceMsg:
 		if m.showingSuccess {
@@ -656,19 +657,41 @@ func (m *Model) startFileWatcher() tea.Cmd {
 	}
 
 	// Start watching for file changes
-	return m.waitForFileChange(w)
+	return m.armFileWatcher()
+}
+
+func (m *Model) armFileWatcher() tea.Cmd {
+	if m.watcher == nil {
+		// Keep command semantics predictable for update paths before Init() wires the watcher.
+		return func() tea.Msg { return nil }
+	}
+	if m.watcherListening {
+		return nil
+	}
+	m.watcherListening = true
+	return m.waitForFileChange(m.watcher)
 }
 
 func (m *Model) waitForFileChange(w *watcher.Watcher) tea.Cmd {
+	if w == nil {
+		return nil
+	}
+
 	return func() tea.Msg {
 		select {
-		case event := <-w.Events():
+		case event, ok := <-w.Events():
+			if !ok {
+				return watcherErrorMsg{err: fmt.Errorf("watcher events channel closed")}
+			}
 			if m.shouldProcessFileEvent(event) {
 				return fileChangedMsg{path: event.Name}
 			}
 			// Event not relevant, continue listening
 			return continueWatchingMsg{}
-		case err := <-w.Errors():
+		case err, ok := <-w.Errors():
+			if !ok {
+				return watcherErrorMsg{err: fmt.Errorf("watcher errors channel closed")}
+			}
 			return watcherErrorMsg{err: err}
 		}
 	}

--- a/internal/validation/orchestrator.go
+++ b/internal/validation/orchestrator.go
@@ -115,6 +115,7 @@ func (to *TestOrchestrator) ValidateExercise(ctx context.Context, ex *exercise.E
 // startServices starts all required services and waits for them to be ready
 func (to *TestOrchestrator) startServices(ctx context.Context, request *ValidationRequest, result *ValidationResult) error {
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	serviceErrors := make(chan error, len(request.Services))
 	
 	for _, serviceSpec := range request.Services {
@@ -134,7 +135,9 @@ func (to *TestOrchestrator) startServices(ctx context.Context, request *Validati
 			if err != nil {
 				serviceResult.Error = fmt.Sprintf("Failed to create service: %v", err)
 				serviceResult.Duration = time.Since(serviceStart)
+				mu.Lock()
 				result.ServiceResults[spec.Name] = serviceResult
+				mu.Unlock()
 				serviceErrors <- err
 				return
 			}
@@ -142,7 +145,9 @@ func (to *TestOrchestrator) startServices(ctx context.Context, request *Validati
 			if err := service.Start(ctx); err != nil {
 				serviceResult.Error = fmt.Sprintf("Failed to start service: %v", err)
 				serviceResult.Duration = time.Since(serviceStart)
+				mu.Lock()
 				result.ServiceResults[spec.Name] = serviceResult
+				mu.Unlock()
 				serviceErrors <- err
 				return
 			}
@@ -154,7 +159,9 @@ func (to *TestOrchestrator) startServices(ctx context.Context, request *Validati
 			if err != nil {
 				serviceResult.Error = fmt.Sprintf("Failed to check service readiness: %v", err)
 				serviceResult.Duration = time.Since(serviceStart)
+				mu.Lock()
 				result.ServiceResults[spec.Name] = serviceResult
+				mu.Unlock()
 				serviceErrors <- err
 				return
 			}
@@ -163,7 +170,9 @@ func (to *TestOrchestrator) startServices(ctx context.Context, request *Validati
 			if !ready {
 				serviceResult.Error = "Service did not become ready within timeout"
 				serviceResult.Duration = time.Since(serviceStart)
+				mu.Lock()
 				result.ServiceResults[spec.Name] = serviceResult
+				mu.Unlock()
 				serviceErrors <- fmt.Errorf("service %s not ready", spec.Name)
 				return
 			}
@@ -172,10 +181,11 @@ func (to *TestOrchestrator) startServices(ctx context.Context, request *Validati
 			connInfo := service.GetConnectionInfo()
 			serviceResult.Connection = connInfo
 			serviceResult.Duration = time.Since(serviceStart)
+			mu.Lock()
 			result.ServiceResults[spec.Name] = serviceResult
-			
 			// Add connection info to environment
 			to.injectServiceEnvironment(spec.Name, connInfo, result.Environment)
+			mu.Unlock()
 			
 			log.Printf("  ✅ Service %s ready in %v", spec.Name, serviceResult.Duration)
 		}(serviceSpec)
@@ -227,6 +237,7 @@ func (to *TestOrchestrator) buildDependencyGraph(rules []ValidationRuleSpec) [][
 // executeBatch executes a batch of validation rules that can run in parallel
 func (to *TestOrchestrator) executeBatch(ctx context.Context, batch []ValidationRuleSpec, request *ValidationRequest, result *ValidationResult) error {
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	ruleErrors := make(chan error, len(batch))
 	
 	for _, ruleSpec := range batch {
@@ -239,12 +250,14 @@ func (to *TestOrchestrator) executeBatch(ctx context.Context, batch []Validation
 			validator, exists := to.validatorRegistry.Get(spec.Type)
 			if !exists {
 				err := fmt.Errorf("unknown validation rule type: %s", spec.Type)
+				mu.Lock()
 				result.ValidationResults[spec.Name] = &RuleResult{
 					RuleName: spec.Name,
 					RuleType: spec.Type,
 					Passed:   false,
 					Error:    err.Error(),
 				}
+				mu.Unlock()
 				ruleErrors <- err
 				return
 			}
@@ -268,7 +281,9 @@ func (to *TestOrchestrator) executeBatch(ctx context.Context, batch []Validation
 				}
 			}
 			
+			mu.Lock()
 			result.ValidationResults[spec.Name] = ruleResult
+			mu.Unlock()
 			
 			if ruleResult.Passed {
 				log.Printf("  ✅ Rule %s passed in %v", spec.Name, ruleResult.Duration)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -43,6 +44,9 @@ type Watcher struct {
 	watcher *fsnotify.Watcher
 	events  chan Event
 	errors  chan error
+	done    chan struct{}
+	once    sync.Once
+	wg      sync.WaitGroup
 }
 
 // NewWatcher creates a new file system watcher
@@ -56,9 +60,11 @@ func NewWatcher() (*Watcher, error) {
 		watcher: fsWatcher,
 		events:  make(chan Event, 100), // Buffer events to prevent blocking
 		errors:  make(chan error, 10),
+		done:    make(chan struct{}),
 	}
 
 	// Start event processing goroutine
+	w.wg.Add(1)
 	go w.processEvents()
 
 	return w, nil
@@ -77,7 +83,11 @@ func (w *Watcher) Add(path string) error {
 
 // Remove stops watching the specified file or directory
 func (w *Watcher) Remove(path string) error {
-	return w.watcher.Remove(path)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	return w.watcher.Remove(absPath)
 }
 
 // Events returns the events channel
@@ -90,34 +100,54 @@ func (w *Watcher) Errors() <-chan error {
 	return w.errors
 }
 
-// Close stops the watcher and closes all channels
+// Close stops the watcher and closes all channels safely.
 func (w *Watcher) Close() error {
-	if w.watcher != nil {
-		err := w.watcher.Close()
-		close(w.events)
-		close(w.errors)
-		return err
-	}
-	return nil
+	var closeErr error
+
+	w.once.Do(func() {
+		close(w.done)
+		if w.watcher != nil {
+			closeErr = w.watcher.Close()
+		}
+		w.wg.Wait()
+	})
+
+	return closeErr
 }
 
 // processEvents converts fsnotify events to our custom Event type
 func (w *Watcher) processEvents() {
+	defer w.wg.Done()
+	defer close(w.events)
+	defer close(w.errors)
+
 	for {
 		select {
+		case <-w.done:
+			return
 		case event, ok := <-w.watcher.Events:
 			if !ok {
 				return // Watcher closed
 			}
-			w.events <- Event{
-				Name: event.Name,
-				Op:   event.Op,
+			// Ignore pure chmod noise events to reduce spurious wakeups.
+			if event.Op&^fsnotify.Chmod == 0 {
+				continue
+			}
+			ev := Event{Name: event.Name, Op: event.Op}
+			select {
+			case w.events <- ev:
+			case <-w.done:
+				return
 			}
 		case err, ok := <-w.watcher.Errors:
 			if !ok {
 				return // Watcher closed
 			}
-			w.errors <- err
+			select {
+			case w.errors <- err:
+			case <-w.done:
+				return
+			}
 		}
 	}
 }
@@ -128,11 +158,11 @@ func (w *Watcher) WatchRecursive(root string) error {
 		if err != nil {
 			return err
 		}
-		
+
 		if info.IsDir() {
 			return w.Add(path)
 		}
-		
+
 		return nil
 	})
 }


### PR DESCRIPTION
## Summary
This PR fixes the memory creep investigation findings by addressing goroutine accumulation, watcher lifecycle races, unbounded output buffering, and repeated exercise reload growth.

## Changes
- TUI watcher loop (`internal/tui/model.go`)
  - Added single-listener gating with `watcherListening` and `armFileWatcher()`.
  - Prevented duplicate in-flight `waitForFileChange` commands.
  - Re-armed watcher exactly once per event/error cycle.
  - Hardened closed-channel handling in `waitForFileChange`.

- Watcher lifecycle (`internal/watcher/watcher.go`)
  - Added coordinated shutdown with `done` channel, `sync.Once`, and `WaitGroup`.
  - Moved output channel close responsibility to producer goroutine.
  - Added guarded sends to avoid close/send races.
  - Filtered pure `CHMOD` noise events.
  - Normalized `Remove()` to absolute paths.

- Exercise reload growth (`internal/exercise/exercise.go`)
  - `LoadExercises()` now resets `em.exercises` before scanning.

- Runner output memory bounds (`internal/runner/runner.go`)
  - Replaced unbounded stdout/stderr buffers with capped buffers (512KB per stream).
  - Added truncation metadata to output string.

- Validation concurrency safety (`internal/validation/orchestrator.go`)
  - Added mutex protection around shared `ValidationResult` map/env writes in parallel execution paths.

- Changelog updated (`CHANGELOG.md`).

## Validation
- `go test ./internal/{watcher,exercise,runner,tui}`
- `go test -race ./internal/{watcher,tui,runner,exercise}`
- `go test ./internal/validation -run '^$'`
- `go build -o ./bin/goforgo ./cmd/goforgo`

## Notes
These changes are focused on long-running watch mode efficiency and robustness under repeated exercise runs.
