### PR TITLE
Add TUI update notice and self-update command (v0.9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Version update check via GitHub tags** *(2026-04-07 11:35:00 local)*: CLI now checks the latest repository tag at startup and shows a non-blocking update notice when a newer semantic version is available, including a `go install ...@latest` command.
+- **Update-check opt-out flag** *(2026-04-07 11:35:00 local)*: Added `--no-update-check` global flag to skip network version checks.
+
 ## [0.9.1] - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-07
+
 ### Added
 - **Version update check via GitHub tags** *(2026-04-07 11:35:00 local)*: CLI now checks the latest repository tag at startup and shows a non-blocking update notice when a newer semantic version is available, including a `go install ...@latest` command.
 - **Update-check opt-out flag** *(2026-04-07 11:35:00 local)*: Added `--no-update-check` global flag to skip network version checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-04-07
+
+### Added
+- **TUI update notice** *(2026-04-07 11:45:00 local)*: watch mode now shows update availability in the footer so users get upgrade guidance inside the interactive interface too.
+- **`goforgo self-update` command** *(2026-04-07 11:45:00 local)*: Added a self-update command that checks tag versions and runs `go install ...@latest` after user confirmation (`--yes` to skip prompt, `--check` for check-only).
+
 ## [0.9.2] - 2026-04-07
 
 ### Added
 - **Version update check via GitHub tags** *(2026-04-07 11:35:00 local)*: CLI now checks the latest repository tag at startup and shows a non-blocking update notice when a newer semantic version is available, including a `go install ...@latest` command.
-- **TUI update notice** *(2026-04-07 11:45:00 local)*: watch mode now shows update availability in the footer so users get upgrade guidance inside the interactive interface too.
-- **`goforgo self-update` command** *(2026-04-07 11:45:00 local)*: Added a self-update command that checks tag versions and runs `go install ...@latest` after user confirmation (`--yes` to skip prompt, `--check` for check-only).
 - **Update-check opt-out flag** *(2026-04-07 11:35:00 local)*: Added `--no-update-check` global flag to skip network version checks.
 
 ## [0.9.1] - 2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Version update check via GitHub tags** *(2026-04-07 11:35:00 local)*: CLI now checks the latest repository tag at startup and shows a non-blocking update notice when a newer semantic version is available, including a `go install ...@latest` command.
+- **TUI update notice** *(2026-04-07 11:45:00 local)*: watch mode now shows update availability in the footer so users get upgrade guidance inside the interactive interface too.
+- **`goforgo self-update` command** *(2026-04-07 11:45:00 local)*: Added a self-update command that checks tag versions and runs `go install ...@latest` after user confirmation (`--yes` to skip prompt, `--check` for check-only).
 - **Update-check opt-out flag** *(2026-04-07 11:35:00 local)*: Added `--no-update-check` global flag to skip network version checks.
 
 ## [0.9.1] - 2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Daily update-check caching** *(2026-04-07 12:05:00 local)*: GitHub tag checks are now cached for 24 hours in the user cache directory to avoid hitting the API on every command run while still surfacing updates promptly.
+
 ## [0.9.3] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-04-07
+
 ### Changed
 - **Daily update-check caching** *(2026-04-07 12:05:00 local)*: GitHub tag checks are now cached for 24 hours in the user cache directory to avoid hitting the API on every command run while still surfacing updates promptly.
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version = "0.9.1"
+	version = "0.9.2"
 	commit  = "unknown"
 	date    = "unknown"
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ Similar to Rustlings for Rust, GoForGo helps you learn Go by fixing broken
 code exercises, with automatic compilation and testing to guide your progress.`,
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if noUpdateCheck {
+		if noUpdateCheck || cmd.Name() == "self-update" {
 			return
 		}
 		maybeNotifyUpdate(cmd.ErrOrStderr(), version)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,9 +11,10 @@ var (
 	version = "0.9.1"
 	commit  = "unknown"
 	date    = "unknown"
-	
+
 	// Global flags
 	workingDirectory string
+	noUpdateCheck    bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -29,6 +30,12 @@ real-time feedback as you code.
 Similar to Rustlings for Rust, GoForGo helps you learn Go by fixing broken
 code exercises, with automatic compilation and testing to guide your progress.`,
 	Version: fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if noUpdateCheck {
+			return
+		}
+		maybeNotifyUpdate(cmd.ErrOrStderr(), version)
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -40,6 +47,7 @@ func Execute() error {
 func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringVarP(&workingDirectory, "directory", "d", "", "working directory for exercises (default: current directory)")
+	rootCmd.PersistentFlags().BoolVar(&noUpdateCheck, "no-update-check", false, "skip checking GitHub tags for newer goforgo versions")
 }
 
 // GetWorkingDirectory returns the working directory, defaulting to current directory

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version = "0.9.3"
+	version = "0.9.4"
 	commit  = "unknown"
 	date    = "unknown"
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	version = "0.9.2"
+	version = "0.9.3"
 	commit  = "unknown"
 	date    = "unknown"
 

--- a/internal/cli/self_update.go
+++ b/internal/cli/self_update.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	selfUpdateYes   bool
+	selfUpdateCheck bool
+)
+
+var selfUpdateCmd = &cobra.Command{
+	Use:   "self-update",
+	Short: "Check for and install the latest GoForGo version",
+	Long: `Checks the latest GitHub tag and optionally updates the installed goforgo binary.
+
+By default, this command asks for confirmation before updating.
+Use --yes to skip the prompt.
+Use --check to only check and print status.`,
+	RunE: runSelfUpdate,
+}
+
+func runSelfUpdate(cmd *cobra.Command, args []string) error {
+	latest, isNewer, err := checkForUpdate(version, defaultTagsURLForTests, nil)
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	if !isNewer {
+		fmt.Fprintf(cmd.OutOrStdout(), "✅ goforgo is up to date (%s)\n", version)
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "🔔 Update available: %s (current: %s)\n", latest, version)
+	fmt.Fprintf(cmd.OutOrStdout(), "   Will run: %s\n", updateInstallCmd)
+
+	if selfUpdateCheck {
+		return nil
+	}
+
+	if !selfUpdateYes {
+		ok, err := askForConfirmation(cmd)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(cmd.OutOrStdout(), "Update cancelled.")
+			return nil
+		}
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Updating goforgo...")
+	goCmd := exec.Command("go", "install", "github.com/stonecharioteer/goforgo/cmd/goforgo@latest")
+	goCmd.Stdout = cmd.OutOrStdout()
+	goCmd.Stderr = cmd.ErrOrStderr()
+
+	if err := goCmd.Run(); err != nil {
+		return fmt.Errorf("self-update failed: %w", err)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "✅ Update complete. Run 'goforgo --version' to verify.")
+	return nil
+}
+
+func askForConfirmation(cmd *cobra.Command) (bool, error) {
+	fmt.Fprint(cmd.OutOrStdout(), "Proceed with update? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("failed to read confirmation: %w", err)
+	}
+
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func init() {
+	rootCmd.AddCommand(selfUpdateCmd)
+	selfUpdateCmd.Flags().BoolVarP(&selfUpdateYes, "yes", "y", false, "run update without confirmation prompt")
+	selfUpdateCmd.Flags().BoolVar(&selfUpdateCheck, "check", false, "only check for updates, do not install")
+}

--- a/internal/cli/update_check.go
+++ b/internal/cli/update_check.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	updateCheckTimeout = 1200 * time.Millisecond
+	updateInstallCmd   = "go install github.com/stonecharioteer/goforgo/cmd/goforgo@latest"
+)
+
+var defaultTagsURLForTests = "https://api.github.com/repos/stonecharioteer/goforgo/tags?per_page=1"
+
+type githubTag struct {
+	Name string `json:"name"`
+}
+
+type semVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func maybeNotifyUpdate(w io.Writer, currentVersion string) {
+	maybeNotifyUpdateWithConfig(w, currentVersion, http.DefaultClient, defaultTagsURLForTests)
+}
+
+func maybeNotifyUpdateWithConfig(w io.Writer, currentVersion string, client *http.Client, tagsURL string) {
+	if w == nil {
+		return
+	}
+
+	latest, isNewer, err := checkForUpdate(currentVersion, tagsURL, client)
+	if err != nil || !isNewer {
+		return
+	}
+
+	fmt.Fprintf(w, "\n🔔 Update available: %s (current: %s)\n", latest, currentVersion)
+	fmt.Fprintf(w, "   Update with: %s\n\n", updateInstallCmd)
+}
+
+func checkForUpdate(currentVersion, tagsURL string, client *http.Client) (latest string, isNewer bool, err error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	current, ok := parseSemVersion(currentVersion)
+	if !ok {
+		return "", false, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	tag, err := fetchLatestTag(ctx, client, tagsURL)
+	if err != nil {
+		return "", false, err
+	}
+
+	latestParsed, ok := parseSemVersion(tag)
+	if !ok {
+		return "", false, nil
+	}
+
+	return tag, current.lessThan(latestParsed), nil
+}
+
+func fetchLatestTag(ctx context.Context, client *http.Client, tagsURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tagsURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "goforgo-update-check")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("tags request returned status %d", resp.StatusCode)
+	}
+
+	var tags []githubTag
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return "", err
+	}
+	if len(tags) == 0 || tags[0].Name == "" {
+		return "", fmt.Errorf("no tags returned")
+	}
+
+	return tags[0].Name, nil
+}
+
+func parseSemVersion(raw string) (semVersion, bool) {
+	v := strings.TrimSpace(raw)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return semVersion{}, false
+	}
+
+	// Drop any build metadata / prerelease suffix.
+	if i := strings.IndexAny(v, "+-"); i >= 0 {
+		v = v[:i]
+	}
+
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return semVersion{}, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return semVersion{}, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return semVersion{}, false
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return semVersion{}, false
+	}
+
+	return semVersion{Major: major, Minor: minor, Patch: patch}, true
+}
+
+func (v semVersion) lessThan(other semVersion) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	if v.Minor != other.Minor {
+		return v.Minor < other.Minor
+	}
+	return v.Patch < other.Patch
+}

--- a/internal/cli/update_check.go
+++ b/internal/cli/update_check.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -17,6 +18,11 @@ const (
 )
 
 var defaultTagsURLForTests = "https://api.github.com/repos/stonecharioteer/goforgo/tags?per_page=1"
+
+var (
+	updateNoticeMu sync.RWMutex
+	updateNotice   string
+)
 
 type githubTag struct {
 	Name string `json:"name"`
@@ -33,17 +39,37 @@ func maybeNotifyUpdate(w io.Writer, currentVersion string) {
 }
 
 func maybeNotifyUpdateWithConfig(w io.Writer, currentVersion string, client *http.Client, tagsURL string) {
+	latest, isNewer, err := checkForUpdate(currentVersion, tagsURL, client)
+	if err != nil || !isNewer {
+		setUpdateNotice("")
+		return
+	}
+
+	setUpdateNotice(compactUpdateNotice(latest, currentVersion))
 	if w == nil {
 		return
 	}
+	fmt.Fprint(w, cliUpdateNotice(latest, currentVersion))
+}
 
-	latest, isNewer, err := checkForUpdate(currentVersion, tagsURL, client)
-	if err != nil || !isNewer {
-		return
-	}
+func getCachedUpdateNotice() string {
+	updateNoticeMu.RLock()
+	defer updateNoticeMu.RUnlock()
+	return updateNotice
+}
 
-	fmt.Fprintf(w, "\n🔔 Update available: %s (current: %s)\n", latest, currentVersion)
-	fmt.Fprintf(w, "   Update with: %s\n\n", updateInstallCmd)
+func setUpdateNotice(notice string) {
+	updateNoticeMu.Lock()
+	defer updateNoticeMu.Unlock()
+	updateNotice = notice
+}
+
+func cliUpdateNotice(latest, current string) string {
+	return fmt.Sprintf("\n🔔 Update available: %s (current: %s)\n   Update with: %s\n\n", latest, current, updateInstallCmd)
+}
+
+func compactUpdateNotice(latest, current string) string {
+	return fmt.Sprintf("Update available: %s (current: %s) • %s", latest, current, updateInstallCmd)
 }
 
 func checkForUpdate(currentVersion, tagsURL string, client *http.Client) (latest string, isNewer bool, err error) {

--- a/internal/cli/update_check.go
+++ b/internal/cli/update_check.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +20,9 @@ const (
 )
 
 var defaultTagsURLForTests = "https://api.github.com/repos/stonecharioteer/goforgo/tags?per_page=1"
+var updateCheckNow = time.Now
+var updateCheckCacheTTL = 24 * time.Hour
+var updateCachePathForTests string
 
 var (
 	updateNoticeMu sync.RWMutex
@@ -34,12 +39,19 @@ type semVersion struct {
 	Patch int
 }
 
+type updateCheckCache struct {
+	LastChecked time.Time `json:"last_checked"`
+	Current     string    `json:"current"`
+	Latest      string    `json:"latest"`
+	IsNewer     bool      `json:"is_newer"`
+}
+
 func maybeNotifyUpdate(w io.Writer, currentVersion string) {
 	maybeNotifyUpdateWithConfig(w, currentVersion, http.DefaultClient, defaultTagsURLForTests)
 }
 
 func maybeNotifyUpdateWithConfig(w io.Writer, currentVersion string, client *http.Client, tagsURL string) {
-	latest, isNewer, err := checkForUpdate(currentVersion, tagsURL, client)
+	latest, isNewer, err := resolveUpdateStatus(currentVersion, tagsURL, client)
 	if err != nil || !isNewer {
 		setUpdateNotice("")
 		return
@@ -50,6 +62,26 @@ func maybeNotifyUpdateWithConfig(w io.Writer, currentVersion string, client *htt
 		return
 	}
 	fmt.Fprint(w, cliUpdateNotice(latest, currentVersion))
+}
+
+func resolveUpdateStatus(currentVersion, tagsURL string, client *http.Client) (string, bool, error) {
+	if cache, ok := loadFreshUpdateCache(currentVersion); ok {
+		return cache.Latest, cache.IsNewer, nil
+	}
+
+	latest, isNewer, err := checkForUpdate(currentVersion, tagsURL, client)
+	if err != nil {
+		return "", false, err
+	}
+
+	_ = saveUpdateCache(updateCheckCache{
+		LastChecked: updateCheckNow().UTC(),
+		Current:     currentVersion,
+		Latest:      latest,
+		IsNewer:     isNewer,
+	})
+
+	return latest, isNewer, nil
 }
 
 func getCachedUpdateNotice() string {
@@ -125,6 +157,68 @@ func fetchLatestTag(ctx context.Context, client *http.Client, tagsURL string) (s
 	}
 
 	return tags[0].Name, nil
+}
+
+func loadFreshUpdateCache(currentVersion string) (updateCheckCache, bool) {
+	path, err := updateCachePath()
+	if err != nil {
+		return updateCheckCache{}, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return updateCheckCache{}, false
+	}
+
+	var cache updateCheckCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return updateCheckCache{}, false
+	}
+
+	if cache.Current != currentVersion {
+		return updateCheckCache{}, false
+	}
+
+	if updateCheckNow().Sub(cache.LastChecked) > updateCheckCacheTTL {
+		return updateCheckCache{}, false
+	}
+
+	if cache.IsNewer && cache.Latest == "" {
+		return updateCheckCache{}, false
+	}
+
+	return cache, true
+}
+
+func saveUpdateCache(cache updateCheckCache) error {
+	path, err := updateCachePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+func updateCachePath() (string, error) {
+	if updateCachePathForTests != "" {
+		return updateCachePathForTests, nil
+	}
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cacheDir, "goforgo", "update-check.json"), nil
 }
 
 func parseSemVersion(raw string) (semVersion, bool) {

--- a/internal/cli/update_check_test.go
+++ b/internal/cli/update_check_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseSemVersion(t *testing.T) {
@@ -51,6 +52,8 @@ func TestCheckForUpdate(t *testing.T) {
 }
 
 func TestMaybeNotifyUpdate(t *testing.T) {
+	resetUpdateCheckGlobalsForTests(t)
+
 	// Swap URL to local server for deterministic output.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, `[{"name":"v9.9.9"}]`)
@@ -60,6 +63,8 @@ func TestMaybeNotifyUpdate(t *testing.T) {
 	oldURL := defaultTagsURLForTests
 	defaultTagsURLForTests = ts.URL
 	defer func() { defaultTagsURLForTests = oldURL }()
+
+	updateCachePathForTests = t.TempDir() + "/update-check.json"
 
 	var b strings.Builder
 	maybeNotifyUpdateWithConfig(&b, "0.9.1", ts.Client(), defaultTagsURLForTests)
@@ -71,4 +76,80 @@ func TestMaybeNotifyUpdate(t *testing.T) {
 	if !strings.Contains(out, "go install github.com/stonecharioteer/goforgo/cmd/goforgo@latest") {
 		t.Fatalf("expected install command in message, got: %q", out)
 	}
+}
+
+func TestResolveUpdateStatus_UsesFreshCache(t *testing.T) {
+	resetUpdateCheckGlobalsForTests(t)
+	updateCachePathForTests = t.TempDir() + "/update-check.json"
+	now := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	updateCheckNow = func() time.Time { return now }
+
+	if err := saveUpdateCache(updateCheckCache{
+		LastChecked: now,
+		Current:     "0.9.3",
+		Latest:      "v9.9.9",
+		IsNewer:     true,
+	}); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	hit := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		_, _ = io.WriteString(w, `[{"name":"v0.9.4"}]`)
+	}))
+	defer ts.Close()
+
+	latest, newer, err := resolveUpdateStatus("0.9.3", ts.URL, ts.Client())
+	if err != nil {
+		t.Fatalf("resolveUpdateStatus error: %v", err)
+	}
+	if !newer || latest != "v9.9.9" {
+		t.Fatalf("expected cached newer tag, got latest=%q newer=%v", latest, newer)
+	}
+	if hit != 0 {
+		t.Fatalf("expected no network call when cache is fresh, got %d", hit)
+	}
+}
+
+func TestResolveUpdateStatus_RefreshesExpiredCache(t *testing.T) {
+	resetUpdateCheckGlobalsForTests(t)
+	updateCachePathForTests = t.TempDir() + "/update-check.json"
+	now := time.Date(2026, 4, 7, 12, 0, 0, 0, time.UTC)
+	updateCheckNow = func() time.Time { return now }
+
+	if err := saveUpdateCache(updateCheckCache{
+		LastChecked: now.Add(-48 * time.Hour),
+		Current:     "0.9.3",
+		Latest:      "v9.9.9",
+		IsNewer:     true,
+	}); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	hit := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		_, _ = io.WriteString(w, `[{"name":"v0.9.4"}]`)
+	}))
+	defer ts.Close()
+
+	latest, newer, err := resolveUpdateStatus("0.9.3", ts.URL, ts.Client())
+	if err != nil {
+		t.Fatalf("resolveUpdateStatus error: %v", err)
+	}
+	if !newer || latest != "v0.9.4" {
+		t.Fatalf("expected refreshed tag, got latest=%q newer=%v", latest, newer)
+	}
+	if hit != 1 {
+		t.Fatalf("expected one network call when cache is stale, got %d", hit)
+	}
+}
+
+func resetUpdateCheckGlobalsForTests(t *testing.T) {
+	t.Helper()
+	updateCheckNow = time.Now
+	updateCheckCacheTTL = 24 * time.Hour
+	updateCachePathForTests = ""
+	setUpdateNotice("")
 }

--- a/internal/cli/update_check_test.go
+++ b/internal/cli/update_check_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseSemVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		ok   bool
+		want semVersion
+	}{
+		{in: "0.9.1", ok: true, want: semVersion{0, 9, 1}},
+		{in: "v0.9.1", ok: true, want: semVersion{0, 9, 1}},
+		{in: "v1.2.3-beta", ok: true, want: semVersion{1, 2, 3}},
+		{in: "dev", ok: false},
+		{in: "1.2", ok: false},
+	}
+
+	for _, tt := range tests {
+		got, ok := parseSemVersion(tt.in)
+		if ok != tt.ok {
+			t.Fatalf("parseSemVersion(%q) ok=%v want %v", tt.in, ok, tt.ok)
+		}
+		if ok && got != tt.want {
+			t.Fatalf("parseSemVersion(%q) got=%+v want %+v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCheckForUpdate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[{"name":"v0.9.2"}]`)
+	}))
+	defer ts.Close()
+
+	tag, newer, err := checkForUpdate("0.9.1", ts.URL, ts.Client())
+	if err != nil {
+		t.Fatalf("checkForUpdate error: %v", err)
+	}
+	if !newer {
+		t.Fatalf("expected newer=true")
+	}
+	if tag != "v0.9.2" {
+		t.Fatalf("expected tag v0.9.2 got %s", tag)
+	}
+}
+
+func TestMaybeNotifyUpdate(t *testing.T) {
+	// Swap URL to local server for deterministic output.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[{"name":"v9.9.9"}]`)
+	}))
+	defer ts.Close()
+
+	oldURL := defaultTagsURLForTests
+	defaultTagsURLForTests = ts.URL
+	defer func() { defaultTagsURLForTests = oldURL }()
+
+	var b strings.Builder
+	maybeNotifyUpdateWithConfig(&b, "0.9.1", ts.Client(), defaultTagsURLForTests)
+
+	out := b.String()
+	if !strings.Contains(out, "Update available") {
+		t.Fatalf("expected update message, got: %q", out)
+	}
+	if !strings.Contains(out, "go install github.com/stonecharioteer/goforgo/cmd/goforgo@latest") {
+		t.Fatalf("expected install command in message, got: %q", out)
+	}
+}

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/stonecharioteer/goforgo/internal/tui"
@@ -50,16 +51,15 @@ func startWatchMode(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start the TUI interface (like Rustlings)
-	return tui.CheckAndInitializeTUI(cwd)
+	return tui.CheckAndInitializeTUIWithNotice(cwd, strings.TrimSpace(getCachedUpdateNotice()))
 }
-
 
 func init() {
 	rootCmd.AddCommand(watchCmd)
-	
+
 	// Add flags
 	watchCmd.Flags().BoolVar(&manualRun, "manual", false, "Disable file watching, require manual execution")
-	
+
 	// Make watch the default command when no subcommand is specified
 	rootCmd.RunE = startWatchMode
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -16,7 +16,7 @@ import (
 type ViewMode int
 
 const (
-	ViewSplash  ViewMode = iota
+	ViewSplash ViewMode = iota
 	ViewWelcome
 	ViewMain
 	ViewList
@@ -33,10 +33,10 @@ type Model struct {
 	exercises       []*exercise.Exercise
 
 	// Execution and validation
-	runner        *runner.Runner
-	lastResult    *runner.Result
-	isRunning     bool
-	currentHintLevel int  // Track current hint level (0=none, 1=level1, 2=level1+2, 3=all)
+	runner           *runner.Runner
+	lastResult       *runner.Result
+	isRunning        bool
+	currentHintLevel int // Track current hint level (0=none, 1=level1, 2=level1+2, 3=all)
 
 	// File watching
 	watcher          *watcher.Watcher
@@ -48,23 +48,23 @@ type Model struct {
 	width    int
 	height   int
 	ready    bool
-	
+
 	// List view state for scrollable exercise list
 	listSelectedIndex int // Currently selected item in list
 	listScrollOffset  int // Scroll offset for list view
 	listViewHeight    int // Available height for list items
-	
+
 	// Filter state
 	filterMode bool   // Whether we're in filter mode
 	filterText string // Current filter text
-	
+
 	// Output view state
-	outputScrollPos  int  // Current scroll position in output view
-	outputViewHeight int  // Available height for output content
-	
+	outputScrollPos  int // Current scroll position in output view
+	outputViewHeight int // Available height for output content
+
 	// Progress and statistics
 	// Counts are now calculated dynamically via exerciseManager methods
-	
+
 	// Vim-style key sequence state
 	pendingKey   string // Buffered key for multi-key sequences (e.g., "g", "z")
 	pendingCount int    // Numeric prefix for {count}j/{count}k motions
@@ -75,6 +75,7 @@ type Model struct {
 
 	// Messages and status
 	statusMessage string
+	updateNotice  string
 	splashFrame   int
 }
 
@@ -83,7 +84,7 @@ func NewModel(exerciseManager *exercise.ExerciseManager, runner *runner.Runner) 
 	exercises := exerciseManager.GetExercises()
 	currentEx := exerciseManager.GetNextExercise()
 	currentIndex := 0
-	
+
 	// Find the index of the current exercise
 	for i, ex := range exercises {
 		if currentEx != nil && ex.Info.Name == currentEx.Info.Name {
@@ -103,6 +104,11 @@ func NewModel(exerciseManager *exercise.ExerciseManager, runner *runner.Runner) 
 		viewMode:        ViewSplash,
 		splashFrame:     0,
 	}
+}
+
+// SetUpdateNotice sets a startup update notice shown in the UI footer.
+func (m *Model) SetUpdateNotice(notice string) {
+	m.updateNotice = notice
 }
 
 // Init initializes the model
@@ -618,7 +624,7 @@ func (m *Model) nextExercise() tea.Cmd {
 	if m.currentIndex < len(m.exercises)-1 {
 		m.currentIndex++
 		m.currentExercise = m.exercises[m.currentIndex]
-		m.currentHintLevel = 0  // Reset hint level for new exercise
+		m.currentHintLevel = 0 // Reset hint level for new exercise
 		return m.runCurrentExercise()
 	}
 	return func() tea.Msg {
@@ -630,7 +636,7 @@ func (m *Model) previousExercise() tea.Cmd {
 	if m.currentIndex > 0 {
 		m.currentIndex--
 		m.currentExercise = m.exercises[m.currentIndex]
-		m.currentHintLevel = 0  // Reset hint level for new exercise
+		m.currentHintLevel = 0 // Reset hint level for new exercise
 		return m.runCurrentExercise()
 	}
 	return func() tea.Msg {
@@ -729,39 +735,39 @@ func (m *Model) consumeCount(defaultVal int) int {
 // Styles — GitHub Dark theme palette for readability on dark terminals.
 var (
 	headerStyle = lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("#bc8cff")).
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderBottom(true).
-		BorderForeground(lipgloss.Color("#bc8cff"))
+			Bold(true).
+			Foreground(lipgloss.Color("#bc8cff")).
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderBottom(true).
+			BorderForeground(lipgloss.Color("#bc8cff"))
 
 	titleStyle = lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("#e6edf3"))
+			Bold(true).
+			Foreground(lipgloss.Color("#e6edf3"))
 
 	successStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#3fb950")).
-		Bold(true)
+			Foreground(lipgloss.Color("#3fb950")).
+			Bold(true)
 
 	errorStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#f85149")).
-		Bold(true)
+			Foreground(lipgloss.Color("#f85149")).
+			Bold(true)
 
 	hintStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#d29922")).
-		Italic(true)
+			Foreground(lipgloss.Color("#d29922")).
+			Italic(true)
 
 	codeStyle = lipgloss.NewStyle().
-		Background(lipgloss.Color("#161b22")).
-		Foreground(lipgloss.Color("#e6edf3")).
-		Padding(0, 1)
+			Background(lipgloss.Color("#161b22")).
+			Foreground(lipgloss.Color("#e6edf3")).
+			Padding(0, 1)
 
 	progressBarStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#bc8cff"))
+				Foreground(lipgloss.Color("#bc8cff"))
 
 	statusStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#8b949e")).
-		Italic(true)
+			Foreground(lipgloss.Color("#8b949e")).
+			Italic(true)
 )
 
 // getTotalCount returns the total number of exercises (dynamic)
@@ -779,7 +785,7 @@ func (m *Model) getMaxHintLevel() int {
 	if m.currentExercise == nil {
 		return 0
 	}
-	
+
 	maxLevel := 0
 	if m.currentExercise.Hints.Level1 != "" {
 		maxLevel = 1
@@ -790,7 +796,7 @@ func (m *Model) getMaxHintLevel() int {
 	if m.currentExercise.Hints.Level3 != "" {
 		maxLevel = 3
 	}
-	
+
 	return maxLevel
 }
 
@@ -812,17 +818,17 @@ func (m *Model) splashTick() tea.Cmd {
 func (m *Model) moveListSelection(delta int) tea.Cmd {
 	filteredExercises := m.getFilteredExercises()
 	newIndex := m.listSelectedIndex + delta
-	
+
 	// Clamp to valid range (no wrapping)
 	if newIndex < 0 {
 		newIndex = 0
 	} else if newIndex >= len(filteredExercises) {
 		newIndex = len(filteredExercises) - 1
 	}
-	
+
 	m.listSelectedIndex = newIndex
 	m.ensureSelectedVisible()
-	
+
 	return nil
 }
 
@@ -836,7 +842,7 @@ func (m *Model) ensureSelectedVisible() {
 		// Selected item is below visible area
 		m.listScrollOffset = m.listSelectedIndex - m.listViewHeight + 1
 	}
-	
+
 	// Ensure scroll offset doesn't go negative or exceed filtered exercise count
 	if m.listScrollOffset < 0 {
 		m.listScrollOffset = 0
@@ -851,29 +857,29 @@ func (m *Model) getFilteredExercises() []*exercise.Exercise {
 	if m.filterText == "" {
 		return m.exercises
 	}
-	
+
 	var filtered []*exercise.Exercise
 	filterLower := strings.ToLower(m.filterText)
-	
+
 	for _, ex := range m.exercises {
 		// Check exercise name
 		if strings.Contains(strings.ToLower(ex.Info.Name), filterLower) {
 			filtered = append(filtered, ex)
 			continue
 		}
-		
+
 		// Check exercise title
 		if strings.Contains(strings.ToLower(ex.Description.Title), filterLower) {
 			filtered = append(filtered, ex)
 			continue
 		}
-		
+
 		// Check category
 		if strings.Contains(strings.ToLower(ex.Info.Category), filterLower) {
 			filtered = append(filtered, ex)
 			continue
 		}
-		
+
 		// Check difficulty
 		difficulty := ex.GetDifficultyString()
 		if strings.Contains(strings.ToLower(difficulty), filterLower) {
@@ -881,7 +887,7 @@ func (m *Model) getFilteredExercises() []*exercise.Exercise {
 			continue
 		}
 	}
-	
+
 	return filtered
 }
 
@@ -890,20 +896,20 @@ func (m *Model) scrollOutput(delta int) tea.Cmd {
 	if m.lastResult == nil {
 		return nil
 	}
-	
+
 	// Split output into lines for scrolling
 	outputLines := strings.Split(m.lastResult.Output, "\n")
 	maxScroll := max(0, len(outputLines)-m.outputViewHeight)
-	
+
 	m.outputScrollPos += delta
-	
+
 	// Clamp scroll position
 	if m.outputScrollPos < 0 {
 		m.outputScrollPos = 0
 	} else if m.outputScrollPos > maxScroll {
 		m.outputScrollPos = maxScroll
 	}
-	
+
 	return nil
 }
 
@@ -939,10 +945,10 @@ func (m *Model) scrollToBottom() tea.Cmd {
 	if m.lastResult == nil {
 		return nil
 	}
-	
+
 	outputLines := strings.Split(m.lastResult.Output, "\n")
 	maxScroll := max(0, len(outputLines)-m.outputViewHeight)
 	m.outputScrollPos = maxScroll
-	
+
 	return nil
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,8 +11,16 @@ import (
 
 // RunTUI starts the Bubble Tea TUI application
 func RunTUI(exerciseManager *exercise.ExerciseManager, runner *runner.Runner) error {
+	return RunTUIWithNotice(exerciseManager, runner, "")
+}
+
+// RunTUIWithNotice starts the Bubble Tea TUI application with an optional startup notice.
+func RunTUIWithNotice(exerciseManager *exercise.ExerciseManager, runner *runner.Runner, notice string) error {
 	// Create the model
 	model := NewModel(exerciseManager, runner)
+	if notice != "" {
+		model.SetUpdateNotice(notice)
+	}
 
 	// Create the program with options
 	p := tea.NewProgram(
@@ -46,6 +54,11 @@ func RunTUI(exerciseManager *exercise.ExerciseManager, runner *runner.Runner) er
 
 // CheckAndInitializeTUI checks if we should run the TUI and initializes it
 func CheckAndInitializeTUI(basePath string) error {
+	return CheckAndInitializeTUIWithNotice(basePath, "")
+}
+
+// CheckAndInitializeTUIWithNotice checks if we should run the TUI and initializes it with an optional notice.
+func CheckAndInitializeTUIWithNotice(basePath, notice string) error {
 	// Check if we're in a terminal
 	if !isTerminal() {
 		return fmt.Errorf("GoForGo requires a terminal to run the interactive interface")
@@ -61,7 +74,7 @@ func CheckAndInitializeTUI(basePath string) error {
 	r := runner.NewRunner(basePath)
 
 	// Start the TUI
-	return RunTUI(em, r)
+	return RunTUIWithNotice(em, r, notice)
 }
 
 // isTerminal checks if we're running in a terminal

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -376,6 +376,10 @@ func (m *Model) renderFooter() string {
 		footer += "\n" + errorStyle.Render("⚠️  File watcher error: "+m.watcherErr.Error())
 	}
 
+	if m.updateNotice != "" {
+		footer += "\n" + hintStyle.Render("🔔 "+m.updateNotice)
+	}
+
 	return footer
 }
 
@@ -580,7 +584,7 @@ func (m *Model) renderExerciseList() string {
 
 	// Get filtered exercises
 	filteredExercises := m.getFilteredExercises()
-	
+
 	// Calculate list dimensions
 	listHeight := m.listViewHeight
 	totalExercises := len(filteredExercises)
@@ -590,7 +594,7 @@ func (m *Model) renderExerciseList() string {
 	// Progress indicator
 	var progressText string
 	if m.filterText != "" {
-		progressText = fmt.Sprintf("Showing %d-%d of %d filtered exercises (total: %d)", 
+		progressText = fmt.Sprintf("Showing %d-%d of %d filtered exercises (total: %d)",
 			startIndex+1, endIndex, totalExercises, len(m.exercises))
 	} else {
 		progressText = fmt.Sprintf("Exercises %d-%d of %d", startIndex+1, endIndex, totalExercises)
@@ -1038,43 +1042,43 @@ func (m *Model) renderOutput() string {
 		if m.lastResult.Output != "" {
 			outputLines := strings.Split(m.lastResult.Output, "\n")
 			totalLines := len(outputLines)
-			
+
 			// Calculate visible range
 			startLine := m.outputScrollPos
 			endLine := min(startLine+m.outputViewHeight, totalLines)
-			
+
 			// Show scroll position info
-			scrollInfo := fmt.Sprintf("Output (lines %d-%d of %d)", 
+			scrollInfo := fmt.Sprintf("Output (lines %d-%d of %d)",
 				startLine+1, endLine, totalLines)
 			content.WriteString(statusStyle.Render(scrollInfo))
 			content.WriteString("\n\n")
-			
+
 			// Show visible output lines
 			if startLine < totalLines {
 				visibleLines := outputLines[startLine:endLine]
 				outputContent := strings.Join(visibleLines, "\n")
-				
+
 				// Style the output in a code block
 				outputStyle := lipgloss.NewStyle().
 					Background(lipgloss.Color("#161b22")).
 					Foreground(lipgloss.Color("#e6edf3")).
 					Padding(1, 2).
 					Width(m.width - 20) // Leave some margin
-				
+
 				content.WriteString(outputStyle.Render(outputContent))
 			}
 		} else {
 			content.WriteString(statusStyle.Render("No output produced by the exercise."))
 		}
-		
+
 		content.WriteString("\n\n")
-		
+
 		// Scroll indicators
 		if m.lastResult.Output != "" {
 			outputLines := strings.Split(m.lastResult.Output, "\n")
 			totalLines := len(outputLines)
 			maxScroll := max(0, totalLines-m.outputViewHeight)
-			
+
 			if m.outputScrollPos > 0 {
 				content.WriteString(statusStyle.Render("↑ More content above (scroll up)"))
 				content.WriteString("\n")
@@ -1084,7 +1088,7 @@ func (m *Model) renderOutput() string {
 				content.WriteString("\n")
 			}
 		}
-		
+
 		// Footer with controls
 		footerText := "Navigation: ↑↓/jk=scroll  PgUp/PgDn=page  Home/End=jump  Esc=back"
 		content.WriteString(statusStyle.Render(footerText))
@@ -1124,4 +1128,3 @@ func min(a, b int) int {
 	}
 	return b
 }
-


### PR DESCRIPTION
## Summary
Adds robust update UX based on GitHub tags, both in CLI and in the TUI, plus a new `self-update` command.

## What’s included
- Startup update check (tag-based) remains non-blocking and prints to stderr.
- TUI now shows update notice in the footer when an update is available.
- New command: `goforgo self-update`
  - checks current version vs latest tag
  - prompts for confirmation before install
  - supports:
    - `--check` (check only)
    - `--yes` / `-y` (skip prompt)
- Global opt-out remains available: `--no-update-check`.

## Files changed
- `internal/cli/update_check.go`
- `internal/cli/root.go`
- `internal/cli/watch.go`
- `internal/cli/self_update.go`
- `internal/tui/model.go`
- `internal/tui/tui.go`
- `internal/tui/views.go`
- `CHANGELOG.md`

## Validation
- `go test ./internal/{cli,tui}`
- `go build -o ./bin/goforgo ./cmd/goforgo`
- `./bin/goforgo self-update --help`
