### PR TITLE
feat: add skip-TODO-check toggle to TUI watch mode

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -40,8 +40,9 @@ type ValidationResult struct {
 
 // Runner handles Go code compilation and execution
 type Runner struct {
-	workingDir string
-	timeout    time.Duration
+	workingDir    string
+	timeout       time.Duration
+	SkipTodoCheck bool
 }
 
 const maxCommandOutputBytes = 512 * 1024 // 512KB per stream
@@ -233,11 +234,11 @@ func (r *Runner) RunExercise(ex *exercise.Exercise) (*Result, error) {
 	}
 
 	// Universal TODO comment check - runs after main validation if it succeeded
-	if result.Success {
+	if result.Success && !r.SkipTodoCheck {
 		todoPresent, todoOutput := r.checkForTodoComments(ex.FilePath)
 		result.Validation.TodoCheck = !todoPresent
 		result.Validation.TodoOutput = todoOutput
-		
+
 		if todoPresent {
 			result.Success = false
 			result.Output = todoOutput

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -73,6 +73,9 @@ type Model struct {
 	autoAdvance    bool // When true, auto-advance to next exercise on success
 	showingSuccess bool // True during the success crossfade screen
 
+	// Skip TODO check mode
+	skipTodoCheck bool // When true, TODO comments do not block exercise completion
+
 	// Messages and status
 	statusMessage string
 	updateNotice  string
@@ -270,6 +273,20 @@ func (m *Model) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.statusMessage = "Auto-advance: OFF"
 			}
 			return m, nil
+		}
+		return m, nil
+
+	case "t":
+		// Toggle skip-TODO-check mode
+		if m.viewMode == ViewMain {
+			m.skipTodoCheck = !m.skipTodoCheck
+			m.runner.SkipTodoCheck = m.skipTodoCheck
+			if m.skipTodoCheck {
+				m.statusMessage = "Skip TODO check: ON"
+			} else {
+				m.statusMessage = "Skip TODO check: OFF"
+			}
+			return m, m.runCurrentExercise()
 		}
 		return m, nil
 

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -356,6 +356,11 @@ func (m *Model) renderFooter() string {
 		autoAdvanceLabel = "[a] auto-adv:ON"
 	}
 
+	skipTodoLabel := "[t] skip-todo"
+	if m.skipTodoCheck {
+		skipTodoLabel = "[t] skip-todo:ON"
+	}
+
 	shortcuts := []string{
 		"[n] next",
 		"[p] prev",
@@ -364,6 +369,7 @@ func (m *Model) renderFooter() string {
 		"[r] run",
 		"[s] output",
 		autoAdvanceLabel,
+		skipTodoLabel,
 		"[q] quit",
 	}
 


### PR DESCRIPTION
## Summary

- Adds a `[t]` keyboard shortcut in the main watch view to toggle whether TODO comments block exercise completion
- When enabled (`[t] skip-todo:ON`), exercises pass validation even if TODO comments remain in the file
- The footer reflects the current state, consistent with how `[a] auto-adv` works

## Motivation

Right now, solving an exercise always requires removing every `// TODO` comment before the exercise is considered complete. This can interrupt the flow for users who want to mark progress, take notes inside the file, or explore beyond the exercise without being blocked by leftover markers.

The toggle is opt-in and off by default, so existing behaviour is unchanged.

## Changes

| File | Change |
|------|--------|
| `internal/runner/runner.go` | Added `SkipTodoCheck bool` to `Runner`; gates the TODO check behind it |
| `internal/tui/model.go` | Added `skipTodoCheck` field; `t` key toggles it and syncs to runner |
| `internal/tui/views.go` | Footer shows `[t] skip-todo` / `[t] skip-todo:ON` |

## Test plan

- [ ] Launch `goforgo`, open an exercise with a TODO comment
- [ ] Verify exercise fails with TODO present (default behaviour)
- [ ] Press `t` — status bar shows `Skip TODO check: ON`, footer shows `[t] skip-todo:ON`
- [ ] Verify exercise now passes despite TODO comment remaining
- [ ] Press `t` again — status bar shows `Skip TODO check: OFF`, TODO check resumes